### PR TITLE
Bump carbon identity framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2262,7 +2262,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.281</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.284</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
## Description
Bump carbon identity framework version to `5.25.284`

## Related issue
- https://github.com/wso2/product-is/issues/16423

## Related PR
- https://github.com/wso2/carbon-identity-framework/pull/4851